### PR TITLE
Add miRDeep2

### DIFF
--- a/bimsb/packages/bioinformatics-nonfree.scm
+++ b/bimsb/packages/bioinformatics-nonfree.scm
@@ -1,6 +1,7 @@
 ;;; GNU Guix --- Functional package management for GNU
 ;;; Copyright © 2015, 2016, 2017, 2018 Ricardo Wurmus <ricardo.wurmus@mdc-berlin.de>
 ;;; Copyright © 2017 CM Massimo <carlomaria.massimo@mdc-berlin.de>
+;;; Copyright © 2018 Marcel Schilling <marcel.schilling@mdc-berlin.de>
 ;;;
 ;;; This file is NOT part of GNU Guix, but is supposed to be used with GNU
 ;;; Guix and thus has the same license.
@@ -1882,3 +1883,101 @@ MACE is a bioinformatics tool dedicated to analyze ChIP-exo data.")
     ;; others say "free for all use", others say "GPL version 1.3" (?), yet
     ;; others say "Artistic license".
     (license license:gpl2+)))
+
+;; Although this program is released under the GPL it depends on
+;; ViennaRNA and bowtie1, which are non-free software.
+(define-public mirdeep2
+  (package
+    (name "mirdeep2")
+    (version "0.1.0")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                   (url "https://github.com/rajewsky-lab/mirdeep2.git")
+                   (commit (string-append "v" version))))
+              (file-name (string-append name "-" version "-checkout"))
+              (sha256
+               (base32
+                "0srxxymxmpfb656g6r26zhplx9fl6wxrzzdl6wr7r06nnmx6sjd2"))))
+    (build-system gnu-build-system)
+    (arguments
+     `(#:tests? #f ;; no check target
+       #:phases
+       (modify-phases %standard-phases
+         (delete 'configure)
+         (replace 'build
+           (lambda* (#:key inputs outputs #:allow-other-keys)
+             (let ((out (assoc-ref outputs "out")))
+               ;; patch scripts checking for ../install_successful file
+               (for-each
+                 (lambda (script)
+                   (substitute* script
+                     (("\\$bn/\\.\\./install_successful")
+                      (string-append out
+                                     "/share/mirdeep2/install_successful"))))
+                 '("src/mapper.pl"
+                   "src/miRDeep2.pl"
+                   "src/quantifier.pl"))
+               ;; patch script using ../Rfam_for_miRDeep.fa file
+               (substitute* "src/miRDeep2.pl"
+                 (("\\$\\{scripts\\}/\\.\\./Rfam_for_miRDeep\\.fa")
+                  (string-append out "/share/mirdeep2/Rfam_for_miRDeep.fa"))
+                 (("\\$scripts/\\.\\./Rfam_for_miRDeep\\.fa")
+                  (string-append out "/share/mirdeep2/Rfam_for_miRDeep.fa"))))
+               ;; patch script using $(dirname `which miRDeep2.pl`)/indexes dir
+               (substitute* "src/make_html.pl"
+                 (("`which miRDeep2\\.pl`")
+                  "`realpath ~/.local/share/mirdeep2` . \"/\"")
+                 (("mkdir \"\\$\\{scripts\\}indexes")
+                  "mkdir -p \"${scripts}indexes"))
+             #t))
+         (replace 'install
+           (lambda* (#:key inputs outputs #:allow-other-keys)
+             (let ((out (assoc-ref outputs "out")))
+               (with-directory-excursion "src"
+                 (copy-recursively "." (string-append out "/bin")))
+               ;; place Rfam_for_miRDeep.fa in /share/mirdeep2
+               (mkdir-p (string-append out "/share/mirdeep2"))
+               (copy-file
+                 "Rfam_for_miRDeep.fa"
+                 (string-append out "/share/mirdeep2/Rfam_for_miRDeep.fa"))
+               ;; create install_successful file in share/mirdeep2
+               (with-output-to-file
+                 (string-append out "/share/mirdeep2/install_successful")
+                 (const #t)))  ;; simply touch the file
+             #t))
+         (add-after 'install 'wrap-perl-scripts
+          (lambda* (#:key inputs outputs #:allow-other-keys)
+            (let ((out (assoc-ref outputs "out")))
+              ;; Make sure perl scripts find all perl inputs at runtime.
+              (for-each (lambda (prog)
+                          (wrap-program (string-append out "/bin/" prog)
+                            `("PERL5LIB" ":" prefix
+                              (,(getenv "PERL5LIB")))))
+                        '("make_html2.pl"
+                          "make_html.pl"
+                          "miRDeep2.pl"))
+              ;; Make sure perl scripts find all input binaries at runtime.
+              (for-each (lambda (prog)
+                          (wrap-program (string-append out "/bin/" prog)
+                            `("PATH" ":" prefix
+                               (,(getenv "PATH")))))
+                        '("make_html2.pl"
+                          "make_html.pl"
+                          "mapper.pl"
+                          "miRDeep2_core_algorithm.pl"
+                          "miRDeep2.pl"
+                          "prepare_signature.pl"
+                          "quantifier.pl"))
+              #t))))))
+    (inputs
+      `(("bowtie1" ,bowtie1)
+       ("perl-pdf-api2" ,perl-pdf-api2)
+       ("perl" ,perl)
+       ("randfold" ,randfold)
+       ("viennarna" ,viennarna-2.2.10)))
+    (synopsis "Discovering known and novel miRNAs from small RNA sequencing data")
+    (description "miRDeep2 discovers active known or novel miRNAs from deep
+sequencing data (Solexa/Illumina, 454, ...).")
+    (home-page "https://www.mdc-berlin.de/8551903/en/")
+    (license license:gpl3+)))


### PR DESCRIPTION
This PR depends on https://github.com/BIMSBbioinfo/guix-bimsb/pull/1.

This is my first (serious) attempt of packaging for Guix. So I'm sure there are several things to improve about this.

miRDeep2 doesn't have a `LICENSE` file on github but I double-checked with all authors that it is released under GLP3+. The github repository will reflect this soon.
However, as miRDeep2 depends on bowtie1 which is released under a non-free artistic license, I had to include it here.

The following points are the ones I'm the most uncertain about:

1. How can I make mirdeep2 use viennarna 2.2.10? If I `guix package -i viennarna` I get that one but mirdeep2 propagates 2.2.8.
2. Do I need native or propagated inputs anywhere (else)?
3. Does it matter where I placed the packages (is there any particular order)?
4. Did I break any style guidelines?

Let me know what to change and I'll amend my commit accordingly so we don't have any broken commit in the history.

---
Also here, I'd like to have @rekado have a look (in case that wasn't clear). :wink: