### PR TITLE
Add missing module import (bioconductor).

### DIFF
--- a/bimsb/packages/tainted.scm
+++ b/bimsb/packages/tainted.scm
@@ -1,5 +1,6 @@
 ;;; GNU Guix --- Functional package management for GNU
 ;;; Copyright © 2019 Ricardo Wurmus <ricardo.wurmus@mdc-berlin.de>
+;;; Copyright © 2019 Marcel Schilling <marcel.schilling@mdc-berlin.de>
 ;;;
 ;;; This file is NOT part of GNU Guix, but is supposed to be used with GNU
 ;;; Guix and thus has the same license.
@@ -40,7 +41,8 @@
   #:use-module (gnu packages statistics)
   #:use-module (bimsb packages staging)
   #:use-module (bimsb packages variants)
-  #:use-module (bimsb packages bioinformatics-nonfree))
+  #:use-module (bimsb packages bioinformatics-nonfree)
+  #:use-module (bioconductor nonfree))
 
 ;; Tainted because of the dependency on the non-free Math::CDF.
 (define-public mrin


### PR DESCRIPTION
This does for bec99aef6e4ec8313ff8dea0de5c785b613027ad what a18f4ddf213a12142a7815954b8b20803b45e084 did for e2ffcf3e0f9ad241232cf3c897e6ba4626aea9a8.

---
@ Madalin:
Contrary to what I wrote in my email, the module had to be added to the `(bimsb packages tainted)` module as this search shows: https://github.com/BIMSBbioinfo/guix-bimsb-nonfree/search?q=r-rankprod