### PR TITLE
gnu: Use git-version where applicable/possible

### DIFF
--- a/bimsb/packages/bioinformatics-nonfree.scm
+++ b/bimsb/packages/bioinformatics-nonfree.scm
@@ -690,8 +690,7 @@ structural and functional information.")
         (revision "1"))
     (package
       (name "medicc")
-      (version (string-append "0.0.0-" revision "."
-                              (string-take commit 7)))
+      (version (git-version "0.0.0" revision commit))
       (source (origin
                 (method git-fetch)
                 (uri (git-reference
@@ -775,9 +774,7 @@ structural and functional information.")
                (uri (git-reference
                      (url "https://bitbucket.org/rfs/fstframework.git")
                      (commit commit)))
-               (file-name (string-append "fstframework-"
-                                         "0.0.0-" revision "."
-                                         (string-take commit 7)))
+               (file-name (git-version "0.0.0" revision commit))
                (sha256
                 (base32
                  "0s1483vz14fz1b7l8cs0hll70wn55dpfmdswmy7fqfq6w20q4lwl")))))))
@@ -1117,7 +1114,7 @@ preparation protocols.")
         (revision "1"))
     (package
       (name "python2-rnaseqlib")
-      (version (string-append "0.0.0-" revision "." (string-take commit 7)))
+      (version (git-version "0.0.0" revision commit))
       (source (origin
                 (method git-fetch)
                 (uri (git-reference

--- a/bimsb/packages/bioinformatics-nonfree.scm
+++ b/bimsb/packages/bioinformatics-nonfree.scm
@@ -349,7 +349,7 @@ depths and differentiate reliable RDNPs from the background noise.")
         (revision "1"))
     (package
       (name "fstitch")
-      (version (string-append "0-" revision "." (string-take commit 9)))
+      (version (git-version "0" revision commit))
       (source (origin
                 (method git-fetch)
                 (uri (git-reference
@@ -639,8 +639,7 @@ sequences with a predefined structure (inverse folding) is provided.")
         (commit "a3da753118db8310d453669aa01d34a270532a4b"))
     (package
       (name "nofold")
-      (version (string-append "0.0.0-"
-                              revision "." (string-take commit 9)))
+      (version (git-version "0.0.0" revision commit))
       (source (origin
                 (method git-fetch)
                 (uri (git-reference
@@ -1006,7 +1005,7 @@ requires the author's consent."))))
         (revision "1"))
     (package
       (name "music")
-      (version (string-append "0.0.0-" revision "." (string-take commit 9)))
+      (version (git-version "0.0.0" revision commit))
       (source (origin
                 (method git-fetch)
                 (uri (git-reference


### PR DESCRIPTION
This is basically the analogous PR to https://github.com/BIMSBbioinfo/guix-bimsb/pull/12.
However, in this case some existing package definitions included the first 7 characters of the commit hash in the version only, unlike the 9 ones used for others. Thus, I split those into a separate commit allowing @rekado to decide more conveniently if to change these as well or keep them as-is.